### PR TITLE
New Feature - Zoho Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,33 @@ feed.1.format = {title}, {body}, {url}
 feed.foo.channel = testing
 feed.foo.url = http://url.to.rss.feed
 ```
+
+### Zoho Plugin
+
+Zoho Webhooks are not data-compatible with Mattermost, so we need a
+gateway to reformat what we get.
+
+This adds a generic webhook with a configurable URL. You can then POST
+anything to it with a message parameter (POST data or query string is
+accepted). This will be sent to the configured mattermost channel.
+
+Configure the plugin like this (Assuming you have a "testing" channel
+configured).
+
+Then, create a Webhook in Zoho to point to the matching URL on your server
+(See menu in Setup - Automation - Actions - Webhooks).
+
+The webhook should have a single parameter named "message" under the
+"Parameters in the User Defined Format" section. Put the message with any
+placeholders you like there.
+
+Afterwards, you can create a workflow rule to trigger this webhook according to
+your needs.
+
+```ini
+
+[plugin matterpy.contrib.zoho2mattermost]
+
+listen = /zoho/eemaeg9WahYa7Aelahch
+channel = testing
+```

--- a/matterpy/contrib/zoho2mattermost.py
+++ b/matterpy/contrib/zoho2mattermost.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+
+from aiohttp.web import Response
+
+
+def init(manager, conf):
+
+    async def handle_request(request):
+
+        post_data = await request.post()
+        data = {}
+        data.update(request.query)
+        data.update(post_data)
+
+        message = data.get('message', '')
+
+        await manager.send(
+            conf.get('channel'),
+            message
+        )
+        return Response(body=b'ok')
+
+    manager.register_generic_hook(
+        'POST',
+        conf.get('listen'),
+        handle_request
+    )
+

--- a/matterpy/main.py
+++ b/matterpy/main.py
@@ -29,6 +29,8 @@ def operate(conf):
     mgr = manager.Manager(conf)
     srv = server.Server(conf, mgr)
 
+    srv.setup_generic(mgr.generic_hooks)
+
     srv.run()
 
     loop = asyncio.get_event_loop()

--- a/matterpy/manager.py
+++ b/matterpy/manager.py
@@ -11,7 +11,8 @@ class Manager():
 
     def __init__(self, conf):
         self.conf = conf
-        self.plugins = []
+        self.message_handlers = []
+        self.generic_hooks = {}
         self.load_plugins()
 
     def load_plugins(self):
@@ -31,13 +32,20 @@ class Manager():
             print("Error during module init: %s" % str(exc))
 
     def register(self, plugin):
-        self.plugins.append(plugin)
+        "Deprecated! Alias for register_"
+        return self.register_message_handler(plugin)
+
+    def register_message_handler(self, plugin):
+        self.message_handlers.append(plugin)
+
+    def register_generic_hook(self, method, url, plugin):
+        self.generic_hooks[(method, url)] = plugin
 
     async def receive(self, channel, data):
         reply = partial(self.send, channel)
-        for plugin in self.plugins:
+        for handler in self.message_handlers:
             try:
-                await plugin(data, reply)
+                await handler(data, reply)
             except Exception as exc:
                 print("Error while handling module: %s %s" % (
                     type(exc), str(exc)))

--- a/matterpy/server.py
+++ b/matterpy/server.py
@@ -21,6 +21,21 @@ class Server():
                                       '/%s' % identifier,
                                       partial(self.handle, channel))
 
+    def setup_generic(self, hooks):
+        """
+        Setup generic webhook callbacks.
+
+        Those should be fed in from the manager in the form of a dict:
+        {(method, url): callback}
+        """
+        for ((method, url), callback) in hooks.items():
+            print(" Generic route: %s" % url)
+            self.app.router.add_route(
+                method,
+                url,
+                callback
+            )
+
     def run(self):
         web.run_app(
             self.app,


### PR DESCRIPTION
Zoho Webhooks are not data-compatible with Mattermost, so we need a
gateway to reformat what we get.

This adds a generic webhook with a configurable URL. You can then POST
anything to it with a message parameter (POST data or query string is
accepted). This will be sent to the configured mattermost channel.